### PR TITLE
Change toggle name and argument structure

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -609,7 +609,7 @@ Returns **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Ref
 A function that returns a React HOC that provides a toggle value and toggle function to the wrapped component.
 For each toggle name given, the wrapped component will receive the following props:
 
-`<toggleName>Active`: a boolean with the current state of the toggle value, default = false.
+`<toggleName>`: a boolean with the current state of the toggle value, default = false.
 
 `set<ToggleName>`: a function that will set the toggle value to a given boolean value.
 
@@ -619,17 +619,17 @@ Toggle also exposes a `togglePropTypes` function to automatically generate PropT
 
 **Parameters**
 
--   `toggles` **...[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** One or more toggle names.
+-   `toggleNames` **([String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) \| [Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array))?= \[]** One or more toggle names.
 
 **Examples**
 
 ```javascript
-function ComponentWithTooltip ({ message, tooltipActive, toggleTooltip, ... }) {
+function ComponentWithTooltip ({ message, tooltipShown, toggleTooltipShown }) {
   return (
     <div>
-      <button onClick={ toggleTooltip }>Click Me</button>
+      <button onClick={ toggleTooltipShown }>Click Me</button>
       { 
-        tooltipActive &&
+        tooltipShown &&
         <div className="tooltip">
           { message }
         </div>
@@ -639,8 +639,9 @@ function ComponentWithTooltip ({ message, tooltipActive, toggleTooltip, ... }) {
 }
 
 ComponentWithTooltip.propTypes = {
-  ...togglePropTypes('tooltip'),
-  message: PropTypes.string
+  ...togglePropTypes('tooltipShown'),
+  message: PropTypes.string.isRequired,
+}
 ```
 
 Returns **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** A HOC that can be used to wrap a component.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpadlab/lp-utils",
-  "version": "2.15.0",
+  "version": "3.0.0",
   "description": "Our Utilities",
   "main": "lib/index.js",
   "repository": "launchpadlab/lp-utils",

--- a/src/toggle.js
+++ b/src/toggle.js
@@ -7,7 +7,7 @@ import getDisplayName from './get-display-name'
  * A function that returns a React HOC that provides a toggle value and toggle function to the wrapped component.
  * For each toggle name given, the wrapped component will receive the following props:
  *
- * `<toggleName>Active`: a boolean with the current state of the toggle value, default = false.
+ * `<toggleName>`: a boolean with the current state of the toggle value, default = false.
  *
  * `set<ToggleName>`: a function that will set the toggle value to a given boolean value.
  *
@@ -15,18 +15,18 @@ import getDisplayName from './get-display-name'
  *
  * Toggle also exposes a `togglePropTypes` function to automatically generate PropTypes for these props.
  * 
- * @param {...string} toggles - One or more toggle names.
+ * @param {String|Array} toggleNames - One or more toggle names.
  * @returns {Function} - A HOC that can be used to wrap a component.
  *
  *
  * @example
  *
- * function ComponentWithTooltip ({ message, tooltipActive, toggleTooltip, ... }) {
+ * function ComponentWithTooltip ({ message, tooltipShown, toggleTooltipShown }) {
  *   return (
  *     <div>
- *       <button onClick={ toggleTooltip }>Click Me</button>
+ *       <button onClick={ toggleTooltipShown }>Click Me</button>
  *       { 
- *         tooltipActive &&
+ *         tooltipShown &&
  *         <div className="tooltip">
  *           { message }
  *         </div>
@@ -36,12 +36,14 @@ import getDisplayName from './get-display-name'
  * }
  * 
  * ComponentWithTooltip.propTypes = {
- *   ...togglePropTypes('tooltip'),
- *   message: PropTypes.string
- *
+ *   ...togglePropTypes('tooltipShown'),
+ *   message: PropTypes.string.isRequired,
+ * }
 **/
 
-export default function toggle (...toggles) {
+export default function toggle (toggleNames=[]) {
+
+  const toggles = Array.isArray(toggleNames) ? toggleNames : [ toggleNames ]
 
   return WrappedComponent =>
 
@@ -64,7 +66,7 @@ export default function toggle (...toggles) {
          * The active state of each toggle
          */
         this.state = toggles.reduce((state, toggle) =>
-          ({ ...state, [toggleStateName(toggle)]: false }),
+          ({ ...state, [toggle]: false }),
           {}
         )
 
@@ -72,7 +74,7 @@ export default function toggle (...toggles) {
          * The setter functions
          */
         this.setters = toggles.reduce((setters, toggle) =>
-          ({ ...setters, [setterFuncName(toggle)]: (val) => this.set.bind(this, toggleStateName(toggle), val)() }),
+          ({ ...setters, [setterFuncName(toggle)]: (val) => this.set.bind(this, toggle, val)() }),
           {}
         )
 
@@ -80,7 +82,7 @@ export default function toggle (...toggles) {
          * The toggle functions
          */
         this.toggles = toggles.reduce((togglers, toggle) =>
-          ({ ...togglers, [toggleFuncName(toggle)]: this.toggle.bind(this, toggleStateName(toggle)) }),
+          ({ ...togglers, [toggleFuncName(toggle)]: this.toggle.bind(this, toggle) }),
           {}
         )
       }
@@ -117,10 +119,6 @@ export default function toggle (...toggles) {
     }
 }
 
-function toggleStateName (toggle) {
-  return camelCase([toggle, 'active'].join(' '))
-}
-
 function setterFuncName (toggle) {
   return camelCase(['set', toggle].join(' '))
 }
@@ -129,10 +127,11 @@ function toggleFuncName (toggle) {
   return camelCase(['toggle', toggle].join(' '))
 }
 
-export function togglePropTypes (...toggles) {
+export function togglePropTypes (toggleNames=[]) {
+  const toggles = Array.isArray(toggleNames) ? toggleNames : [ toggleNames ]
   const propTypes = {}
   toggles.forEach((toggle) => {
-    propTypes[toggleStateName(toggle)] = PropTypes.bool
+    propTypes[toggle] = PropTypes.bool
     propTypes[setterFuncName(toggle)] = PropTypes.func
     propTypes[toggleFuncName(toggle)] = PropTypes.func
   })

--- a/test/toggle.test.js
+++ b/test/toggle.test.js
@@ -11,15 +11,15 @@ test('toggle provides a toggle value and setter function', () => {
   const component = shallow(<Wrapper/>)
 
   // Check props
-  const { testActive, setTest } = component.props()
-  expect(testActive).toBe(false)
+  const { test, setTest } = component.props()
+  expect(test).toBe(false)
   expect(typeof setTest).toBe('function')
 
   // Call setter
   setTest(true)
-  expect(component.props().testActive).toBe(true)
+  expect(component.props().test).toBe(true)
   setTest(false)
-  expect(component.props().testActive).toBe(false)
+  expect(component.props().test).toBe(false)
 
   // Don't allow non-bool values
   expect(() => setTest('string')).toThrow()
@@ -32,25 +32,25 @@ test('toggle provides a toggle value and toggle function', () => {
   const component = shallow(<Wrapper/>)
 
   // Check props
-  const { testActive, toggleTest } = component.props()
-  expect(testActive).toBe(false)
+  const { test, toggleTest } = component.props()
+  expect(test).toBe(false)
   expect(typeof toggleTest).toBe('function')
 
   // Call toggle
   toggleTest()
-  expect(component.props().testActive).toBe(true)
+  expect(component.props().test).toBe(true)
   toggleTest()
-  expect(component.props().testActive).toBe(false)
+  expect(component.props().test).toBe(false)
 })
 
 test('toggleProptypes creates proptypes with the correct name and value', () => {
   const expectedPropTypes = {
-    testActive: PropTypes.bool,
+    test: PropTypes.bool,
     setTest: PropTypes.func,
     toggleTest: PropTypes.func,
-    test2Active: PropTypes.bool,
+    test2: PropTypes.bool,
     setTest2: PropTypes.func,
     toggleTest2: PropTypes.func,
   }
-  expect(togglePropTypes('test', 'test2')).toEqual(expectedPropTypes)
+  expect(togglePropTypes(['test', 'test2'])).toEqual(expectedPropTypes)
 })


### PR DESCRIPTION
Now the passed props and configuration are more similar to `getSet` (#54)

Note that I'm merging into `next-version` instead of master to avoid publishing these changes immediately.