### PR TITLE
Rename onLoad to waitFor

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": [ "es2015", "stage-1", "react" ]
+  "presets": [ "es2015", "stage-1", "react" ],
+  "plugins": [ "babel-plugin-transform-export-default" ]
 }

--- a/docs.md
+++ b/docs.md
@@ -2,23 +2,249 @@
 
 ### Table of Contents
 
--   [camelizeProps](#camelizeprops)
--   [componentWithClass](#componentwithclass)
 -   [deprecate](#deprecate)
--   [flatToNested](#flattonested)
--   [getDisplayName](#getdisplayname)
 -   [getSet](#getset)
--   [modifyProps](#modifyprops)
--   [nestedToFlat](#nestedtoflat)
--   [omitProps](#omitprops)
--   [onLoad](#onload)
 -   [onMount](#onmount)
 -   [onUnmount](#onunmount)
 -   [onUpdate](#onupdate)
+-   [toggle](#toggle)
+-   [camelizeProps](#camelizeprops)
+-   [componentWithClass](#componentwithclass)
+-   [flatToNested](#flattonested)
+-   [getDisplayName](#getdisplayname)
+-   [modifyProps](#modifyprops)
+-   [nestedToFlat](#nestedtoflat)
+-   [omitProps](#omitprops)
+-   [DefaultLoadingComponent](#defaultloadingcomponent)
 -   [selectorForSlice](#selectorforslice)
 -   [sortable](#sortable)
--   [toggle](#toggle)
 -   [validate](#validate)
+
+## deprecate
+
+A function that logs a deprecation warning in the console every time a given function is called.
+If you're deprecating a React component, use `deprecateComponent` as indicated in the example below.
+
+If no message is provided, the default deprecation message is:
+
+-   `<functionName> is deprecated and will be removed in the next version of this library.`
+
+**Parameters**
+
+-   `func` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** The function that is being deprecated
+-   `message` **[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?** A custom message to display
+-   `log` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)?** A function for logging the message (optional, default `console.warn`)
+
+**Examples**
+
+```javascript
+// In my-func.js
+
+function myFunc () {
+  return 'hey!'
+}
+
+export default deprecate(myFunc, 'Do not use!')
+
+// In another file:
+
+import myFunc from './my-func'
+
+myFunc() // -> 'hey!'
+// Console will show warning: 'DEPRECATED: Do not use!'
+
+
+// If you're deprecating a React component, use deprecateComponent as an HOC:
+
+const MyComponent = () => <p>Hi</p>
+export default deprecateComponent('Do not use this component')(MyComponent)
+
+// When component is mounted, console will show warning: 'DEPRECATED: Do not use this component'
+```
+
+## getSet
+
+A function that returns a React HOC that provides values and corresponding setter functions to the wrapped component.
+For each variable name given, the wrapped component will receive the following props:
+
+-   `<variableName>`: the value, default = `null`.
+-   `set<variableName>`: a function that will set the value to a given value.
+
+`getSet` also exposes a `getSetPropTypes` function to automatically generate PropTypes for these props.
+
+**Options**
+
+`getSet` may be passed an options object containing the following keys:
+
+-   `initialValues`: An object containing initial values for the variables
+
+These options can also be passed in as props to the wrapped component.
+
+**Parameters**
+
+-   `varNames` **([string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) \| [Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array))** A variable name or array of variable names
+-   `options` **[object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** Options for the HOC as specified above.
+
+**Examples**
+
+```javascript
+function TabBar ({ currentTab, setCurrentTab, tabs ... }) {
+  return (
+    <div>
+      { 
+        tabs.map(tab => 
+           <Tab 
+             key={ tab } 
+             isActive={ tab === currentTab }
+             onClick={ () => setCurrentTab(tab) }
+           />
+        )
+      }
+    </div>
+  )
+}
+
+TabBar.propTypes = {
+  ...getSetPropTypes('currentTab'),
+  tabs: PropTypes.arrayOf(PropTypes.number),
+}
+
+export default compose(
+   getSet('currentTab', { 
+     intialValues: { 
+       currentTab: 1,
+     },
+   }),
+)(TabBar)
+```
+
+Returns **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** A HOC that can be used to wrap a component.
+
+## onMount
+
+A function that returns a React HOC to handle logic to be run during the `componentDidMount` lifecycle event.
+
+See also: [onUnmount](#onunmount), [onUpdate](#onupdate)
+
+**Parameters**
+
+-   `onComponentDidMount` **([Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function) \| [String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String))** A function or a string reference to a function that will be executed with the component's props.
+
+**Examples**
+
+```javascript
+function MyComponent () {
+   return (
+     ...
+   )
+ }
+
+ function componentDidMount (props) {
+   console.log('Our current props: ', props)
+ }
+
+ export default onMount(componentDidMount)(MyComponent)
+```
+
+Returns **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** A HOC that can be used to wrap a component.
+
+## onUnmount
+
+A function that returns a React HOC to handle logic to be run during the `componentWillUnmount` lifecycle event.
+
+See also: [onMount](#onmount), [onUpdate](#onupdate)
+
+**Parameters**
+
+-   `onComponentWillUnmount` **([Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function) \| [String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String))** A function or a string reference to a function that will be executed with the component's props.
+
+**Examples**
+
+```javascript
+function MyComponent () {
+   return (
+     ...
+   )
+ }
+
+ function componentWillUnmount (props) {
+   console.log('Our current props: ', props)
+ }
+
+ export default onUnmount(componentWillUnmount)(MyComponent)
+```
+
+Returns **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** A HOC that can be used to wrap a component.
+
+## onUpdate
+
+A function that returns a React HOC to handle logic to be run during the `componentDidUpdate` lifecycle event.
+
+See also: [onMount](#onmount), [onUnmount](#onunmount)
+
+**Parameters**
+
+-   `onComponentDidUpdate` **([Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function) \| [String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String))** A function or a string reference to a function that will be passed the current props and the previous props.
+
+**Examples**
+
+```javascript
+function MyComponent () {
+   return (
+     ...
+   )
+ }
+
+ function componentDidUpdate (currentProps, previousProps) {
+   console.log('Props updated!', currentProps, previousProps)
+ }
+
+ export default onUpdate(componentDidUpdate)(MyComponent)
+```
+
+Returns **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** A HOC that can be used to wrap a component.
+
+## toggle
+
+A function that returns a React HOC that provides a toggle value and toggle function to the wrapped component.
+For each toggle name given, the wrapped component will receive the following props:
+
+`<toggleName>`: a boolean with the current state of the toggle value, default = false.
+
+`set<ToggleName>`: a function that will set the toggle value to a given boolean value.
+
+`toggle<ToggleName>`: a function that will toggle the toggle value.
+
+Toggle also exposes a `togglePropTypes` function to automatically generate PropTypes for these props.
+
+**Parameters**
+
+-   `toggleNames` **([String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) \| [Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array))?= \[]** One or more toggle names.
+
+**Examples**
+
+```javascript
+function ComponentWithTooltip ({ message, tooltipShown, toggleTooltipShown }) {
+  return (
+    <div>
+      <button onClick={ toggleTooltipShown }>Click Me</button>
+      { 
+        tooltipShown &&
+        <div className="tooltip">
+          { message }
+        </div>
+      }
+    </div>
+  )
+}
+
+ComponentWithTooltip.propTypes = {
+  ...togglePropTypes('tooltipShown'),
+  message: PropTypes.string.isRequired,
+}
+```
+
+Returns **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** A HOC that can be used to wrap a component.
 
 ## camelizeProps
 
@@ -87,48 +313,6 @@ function Content () {
 //     </section>
 //   )
 // }
-```
-
-## deprecate
-
-A function that logs a deprecation warning in the console every time a given function is called.
-If you're deprecating a React component, use `deprecateComponent` as indicated in the example below.
-
-If no message is provided, the default deprecation message is:
-
--   `<functionName> is deprecated and will be removed in the next version of this library.`
-
-**Parameters**
-
--   `func` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** The function that is being deprecated
--   `message` **[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?** A custom message to display
--   `log` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)?** A function for logging the message (optional, default `console.warn`)
-
-**Examples**
-
-```javascript
-// In my-func.js
-
-function myFunc () {
-  return 'hey!'
-}
-
-export default deprecate(myFunc, 'Do not use!')
-
-// In another file:
-
-import myFunc from './my-func'
-
-myFunc() // -> 'hey!'
-// Console will show warning: 'DEPRECATED: Do not use!'
-
-
-// If you're deprecating a React component, use deprecateComponent as an HOC:
-
-const MyComponent = () => <p>Hi</p>
-export default deprecateComponent('Do not use this component')(MyComponent)
-
-// When component is mounted, console will show warning: 'DEPRECATED: Do not use this component'
 ```
 
 ## flatToNested
@@ -209,64 +393,6 @@ getDisplayName(Foo)) // `Bar`
 ```
 
 Returns **[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The component name if it is possible to determine, otherwise `Component`
-
-## getSet
-
-A function that returns a React HOC that provides values and corresponding setter functions to the wrapped component.
-For each variable name given, the wrapped component will receive the following props:
-
--   `<variableName>`: the value, default = `null`.
--   `set<variableName>`: a function that will set the value to a given value.
-
-`getSet` also exposes a `getSetPropTypes` function to automatically generate PropTypes for these props.
-
-**Options**
-
-`getSet` may be passed an options object containing the following keys:
-
--   `initialValues`: An object containing initial values for the variables
-
-These options can also be passed in as props to the wrapped component.
-
-**Parameters**
-
--   `varNames` **([string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) \| [Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array))** A variable name or array of variable names
--   `options` **[object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** Options for the HOC as specified above.
-
-**Examples**
-
-```javascript
-function TabBar ({ currentTab, setCurrentTab, tabs ... }) {
-  return (
-    <div>
-      { 
-        tabs.map(tab => 
-           <Tab 
-             key={ tab } 
-             isActive={ tab === currentTab }
-             onClick={ () => setCurrentTab(tab) }
-           />
-        )
-      }
-    </div>
-  )
-}
-
-TabBar.propTypes = {
-  ...getSetPropTypes('currentTab'),
-  tabs: PropTypes.arrayOf(PropTypes.number),
-}
-
-export default compose(
-   getSet('currentTab', { 
-     intialValues: { 
-       currentTab: 1,
-     },
-   }),
-)(TabBar)
-```
-
-Returns **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** A HOC that can be used to wrap a component.
 
 ## modifyProps
 
@@ -377,13 +503,13 @@ function Parent () {
 
 Returns **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** A HOC that can be used to wrap a component.
 
-## onLoad
+## DefaultLoadingComponent
 
 A function that returns a React HOC to handle renderWhen logic for loading state.
 
 For the renderWhen param, the type can be one of the following:
 
--   String - The name of a prop to wait for. When the prop is defined and not equal to 'loading', the component will render.
+-   String - The name of a prop to wait for. When the prop is truthy, the component will render.
 -   Function - A function that recieves the component props and returns a boolean. When it returns true, the component will render.
 -   Array - An array of prop names to wait for. Each prop name will be evaluated using the `String` rules.
 -   Object - An object where the keys are prop names and the values are expected values. When the prop values are equal to the expected values, the component will render.
@@ -404,96 +530,12 @@ function MyComponent (name) {
 
  const renderWhen = 'name'
 
- onLoad(renderWhen, MyComponent)
+ waitFor(renderWhen, MyComponent)
  // When prop 'name' value evaluates to true, MyComponent will be rendered.
  // Otherwise, <p>Loading...</p> will be rendered.
 ```
 
 Returns **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** Returns a higher order component (HOC) to handle conditional logic for loading states.
-
-## onMount
-
-A function that returns a React HOC to handle logic to be run during the `componentDidMount` lifecycle event.
-
-See also: [onUnmount](#onunmount), [onUpdate](#onupdate)
-
-**Parameters**
-
--   `onComponentDidMount` **([Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function) \| [String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String))** A function or a string reference to a function that will be executed with the component's props.
-
-**Examples**
-
-```javascript
-function MyComponent () {
-   return (
-     ...
-   )
- }
-
- function componentDidMount (props) {
-   console.log('Our current props: ', props)
- }
-
- export default onMount(componentDidMount)(MyComponent)
-```
-
-Returns **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** A HOC that can be used to wrap a component.
-
-## onUnmount
-
-A function that returns a React HOC to handle logic to be run during the `componentWillUnmount` lifecycle event.
-
-See also: [onMount](#onmount), [onUpdate](#onupdate)
-
-**Parameters**
-
--   `onComponentWillUnmount` **([Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function) \| [String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String))** A function or a string reference to a function that will be executed with the component's props.
-
-**Examples**
-
-```javascript
-function MyComponent () {
-   return (
-     ...
-   )
- }
-
- function componentWillUnmount (props) {
-   console.log('Our current props: ', props)
- }
-
- export default onUnmount(componentWillUnmount)(MyComponent)
-```
-
-Returns **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** A HOC that can be used to wrap a component.
-
-## onUpdate
-
-A function that returns a React HOC to handle logic to be run during the `componentDidUpdate` lifecycle event.
-
-See also: [onMount](#onmount), [onUnmount](#onunmount)
-
-**Parameters**
-
--   `onComponentDidUpdate` **([Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function) \| [String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String))** A function or a string reference to a function that will be passed the current props and the previous props.
-
-**Examples**
-
-```javascript
-function MyComponent () {
-   return (
-     ...
-   )
- }
-
- function componentDidUpdate (currentProps, previousProps) {
-   console.log('Props updated!', currentProps, previousProps)
- }
-
- export default onUpdate(componentDidUpdate)(MyComponent)
-```
-
-Returns **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** A HOC that can be used to wrap a component.
 
 ## selectorForSlice
 
@@ -600,48 +642,6 @@ export default compose(
      sortPath: 'age',
    }),
 )(SortedPeopleList)
-```
-
-Returns **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** A HOC that can be used to wrap a component.
-
-## toggle
-
-A function that returns a React HOC that provides a toggle value and toggle function to the wrapped component.
-For each toggle name given, the wrapped component will receive the following props:
-
-`<toggleName>`: a boolean with the current state of the toggle value, default = false.
-
-`set<ToggleName>`: a function that will set the toggle value to a given boolean value.
-
-`toggle<ToggleName>`: a function that will toggle the toggle value.
-
-Toggle also exposes a `togglePropTypes` function to automatically generate PropTypes for these props.
-
-**Parameters**
-
--   `toggleNames` **([String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) \| [Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array))?= \[]** One or more toggle names.
-
-**Examples**
-
-```javascript
-function ComponentWithTooltip ({ message, tooltipShown, toggleTooltipShown }) {
-  return (
-    <div>
-      <button onClick={ toggleTooltipShown }>Click Me</button>
-      { 
-        tooltipShown &&
-        <div className="tooltip">
-          { message }
-        </div>
-      }
-    </div>
-  )
-}
-
-ComponentWithTooltip.propTypes = {
-  ...togglePropTypes('tooltipShown'),
-  message: PropTypes.string.isRequired,
-}
 ```
 
 Returns **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** A HOC that can be used to wrap a component.

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "babel-cli": "^6.22.2",
     "babel-eslint": "^7.1.1",
     "babel-jest": "^18.0.0",
+    "babel-plugin-transform-export-default": "^7.0.0-alpha.20",
     "babel-polyfill": "^6.23.0",
     "babel-preset-es2015": "^6.22.0",
     "babel-preset-react": "^6.22.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,20 +1,20 @@
-export { default as camelizeProps } from './camelize-props'
-export { default as componentWithClass } from './component-with-class'
+export camelizeProps from './camelize-props'
+export componentWithClass from './component-with-class'
 export { deprecate, deprecateComponent } from './deprecate'
-export { default as flatToNested } from './flat-to-nested'
-export { default as getDisplayName } from './get-display-name'
-export { default as getSet, getSetPropTypes } from './get-set'
-export { default as modifyProps } from './modify-props'
-export { default as nestedToFlat } from './nested-to-flat'
-export { default as omitProps } from './omit-props'
-export { default as onLoad } from './on-load'
+export flatToNested from './flat-to-nested'
+export getDisplayName from './get-display-name'
+export getSet, { getSetPropTypes } from './get-set'
+export modifyProps from './modify-props'
+export nestedToFlat from './nested-to-flat'
+export omitProps from './omit-props'
+export waitFor from './wait-for'
 export {
   onMount,
   onUnmount,
   onUpdate,
 } from './lifecycle'
-export { default as selectorForSlice } from './selector-for-slice'
-export { default as sortable } from './sortable'
-export { default as toggle, togglePropTypes } from './toggle'
-export { default as validate } from './validate'
+export selectorForSlice from './selector-for-slice'
+export sortable from './sortable'
+export toggle, { togglePropTypes } from './toggle'
+export validate from './validate'
 

--- a/src/wait-for.js
+++ b/src/wait-for.js
@@ -1,13 +1,14 @@
 import React from 'react'
-import getOr from 'lodash/fp/getOr'
+import get from 'lodash/fp/get'
 import stubTrue from 'lodash/stubTrue'
 import getDisplayName from './get-display-name'
+import every from 'lodash/every'
 
 /**
  * A function that returns a React HOC to handle renderWhen logic for loading state.
  *
  * For the renderWhen param, the type can be one of the following:
- * * String - The name of a prop to wait for. When the prop is defined and not equal to 'loading', the component will render.
+ * * String - The name of a prop to wait for. When the prop is truthy, the component will render.
  * * Function - A function that recieves the component props and returns a boolean. When it returns true, the component will render.
  * * Array - An array of prop names to wait for. Each prop name will be evaluated using the `String` rules.
  * * Object - An object where the keys are prop names and the values are expected values. When the prop values are equal to the expected values, the component will render.
@@ -25,23 +26,27 @@ import getDisplayName from './get-display-name'
  *
  *  const renderWhen = 'name'
  *
- *  onLoad(renderWhen, MyComponent)
+ *  waitFor(renderWhen, MyComponent)
  *  // When prop 'name' value evaluates to true, MyComponent will be rendered.
  *  // Otherwise, <p>Loading...</p> will be rendered.
 **/
 
-export default function onLoad (renderWhen, LoadingComponent=null) {
+function DefaultLoadingComponent () {
+  return <p>Loading...</p>
+}
+
+export default function waitFor (renderWhen, LoadingComponent=DefaultLoadingComponent) {
 
   const doRender = getRenderCondition(renderWhen)
 
   return WrappedComponent =>
 
-    class OnLoad extends React.Component {
+    class waitFor extends React.Component {
 
       /*
        * A friendly name for React devtools and errors
        */
-      static displayName = `OnLoad(${getDisplayName(WrappedComponent)})`
+      static displayName = `waitFor(${getDisplayName(WrappedComponent)})`
 
       /*
        * A reference to the wrapped component
@@ -49,15 +54,9 @@ export default function onLoad (renderWhen, LoadingComponent=null) {
       static WrappedComponent = WrappedComponent
 
       render () {
-        if (doRender(this.props)) {
-          return <WrappedComponent { ...this.props }/>
-        }
-
-        if (LoadingComponent) {
-          return <LoadingComponent { ...this.props }/>
-        }
-
-        return <p>Loading...</p>
+        return doRender(this.props)
+          ? <WrappedComponent { ...this.props }/>
+          : <LoadingComponent { ...this.props }/>
       }
     }
 }
@@ -72,19 +71,17 @@ function getRenderCondition (renderWhen) {
       return renderWhen
     case 'string':
       return function (props) {
-        return propIsPresent(renderWhen, props)
+        return isTruthy(renderWhen, props)
       }
     case 'array':
       return function (props) {
-        return renderWhen.every(propName => {
-          return propIsPresent(propName, props)
-        })
+        return renderWhen.every(propName => isTruthy(propName, props))
       }
     case 'object':
       return function (props) {
-        return Object.keys(renderWhen).every(prop => {
-          const value = getOr(null, prop, props)
-          return value && value === renderWhen[prop]
+        return every(renderWhen, (value, key) => {
+          const propValue = get(key, props)
+          return propValue === value
         })
       }
     default:
@@ -92,8 +89,7 @@ function getRenderCondition (renderWhen) {
   }
 }
 
-// Returns true if prop is truthy and doesn't equal 'loading'
-function propIsPresent (propName, props) {
-  const value = getOr(null, propName, props)
-  return value && value !== 'loading'
+// Returns true if prop is truthy
+function isTruthy (propName, props) {
+  return !!get(propName, props)
 }

--- a/test/wait-for.test.js
+++ b/test/wait-for.test.js
@@ -1,11 +1,11 @@
 import React from 'react'
 import { mount } from 'enzyme'
-import onLoad from '../src/on-load'
+import { waitFor } from '../src'
 
 test('`renderWhen` is a function', () => {
   const Wrapped = () => <h1>hi</h1>
   const renderWhen = ({ renderMe }) => renderMe
-  const Wrapper = onLoad(renderWhen)(Wrapped)
+  const Wrapper = waitFor(renderWhen)(Wrapped)
   const component = mount(<Wrapper renderMe={ false }/>)
 
   expect(component.find('h1').exists()).toBe(false)
@@ -22,14 +22,14 @@ test('`renderWhen` is a function', () => {
 test('`renderWhen` is a string', () => {
   const Wrapped = () => <h1>hi</h1>
   const renderWhen = 'hello'
-  const Wrapper = onLoad(renderWhen)(Wrapped)
+  const Wrapper = waitFor(renderWhen)(Wrapped)
   const component = mount(<Wrapper hello={ null }/>)
 
   expect(component.find('h1').exists()).toBe(false)
 
   component.setProps({ hello: 'loading' })
 
-  expect(component.find('h1').exists()).toBe(false)
+  expect(component.find('h1').exists()).toBe(true)
 
   component.setProps({ hello: 'done!' })
 
@@ -47,7 +47,7 @@ test('`renderWhen` is a string', () => {
 test('`renderWhen` is an array', () => {
   const Wrapped = () => <h1>hi</h1>
   const renderWhen = ['uno', 'dos']
-  const Wrapper = onLoad(renderWhen)(Wrapped)
+  const Wrapper = waitFor(renderWhen)(Wrapped)
   const component = mount(<Wrapper uno={ null }/>)
 
   expect(component.find('h1').exists()).toBe(false)
@@ -66,13 +66,13 @@ test('`renderWhen` is an array', () => {
 
   component.setProps({ uno: 'loading', dos: 'bye' })
 
-  expect(component.find('h1').exists()).toBe(false)
+  expect(component.find('h1').exists()).toBe(true)
 })
 
 test('`renderWhen` is an object', () => {
   const Wrapped = () => <h1>hi</h1>
   const renderWhen = { uno: 'hi', dos: 'bye' }
-  const Wrapper = onLoad(renderWhen)(Wrapped)
+  const Wrapper = waitFor(renderWhen)(Wrapped)
   const component = mount(<Wrapper uno={ null }/>)
 
   expect(component.find('h1').exists()).toBe(false)
@@ -93,7 +93,7 @@ test('`renderWhen` is an object', () => {
 test('`renderWhen` is something else', () => {
   const Wrapped = () => <h1>hi</h1>
   const renderWhen = 7
-  const Wrapper = onLoad(renderWhen)(Wrapped)
+  const Wrapper = waitFor(renderWhen)(Wrapped)
   const component = mount(<Wrapper uno={ null }/>)
 
   expect(component.find('h1').exists()).toBe(true)
@@ -102,7 +102,7 @@ test('`renderWhen` is something else', () => {
 test('a custom loading component is used', () => {
   const Wrapped = () => <h1>hi</h1>
   const LoadingComponent = () => <label> I am loading </label>
-  const Wrapper = onLoad('doLoad', LoadingComponent)(Wrapped)
+  const Wrapper = waitFor('doLoad', LoadingComponent)(Wrapped)
   const component = mount(<Wrapper />)
   expect(component.find('label').exists()).toBe(true)
   component.setProps({ doLoad: true })

--- a/yarn.lock
+++ b/yarn.lock
@@ -481,6 +481,10 @@ babel-plugin-syntax-exponentiation-operator@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#9ee7e8337290da95288201a6a57f4170317830de"
 
+babel-plugin-syntax-export-extensions@7.0.0-alpha.20:
+  version "7.0.0-alpha.20"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-export-extensions/-/babel-plugin-syntax-export-extensions-7.0.0-alpha.20.tgz#4138ee9bdd362d6ad7ad8c96fb5b8ca1e55c97d7"
+
 babel-plugin-syntax-export-extensions@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-export-extensions/-/babel-plugin-syntax-export-extensions-6.13.0.tgz#70a1484f0f9089a4e84ad44bac353c95b9b12721"
@@ -742,6 +746,12 @@ babel-plugin-transform-exponentiation-operator@^6.22.0:
     babel-helper-builder-binary-assignment-operator-visitor "^6.22.0"
     babel-plugin-syntax-exponentiation-operator "^6.8.0"
     babel-runtime "^6.22.0"
+
+babel-plugin-transform-export-default@^7.0.0-alpha.20:
+  version "7.0.0-alpha.20"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-export-default/-/babel-plugin-transform-export-default-7.0.0-alpha.20.tgz#ffd0f26f1008e4a03cb458018752e43b07d50db0"
+  dependencies:
+    babel-plugin-syntax-export-extensions "7.0.0-alpha.20"
 
 babel-plugin-transform-export-extensions@^6.22.0:
   version "6.22.0"


### PR DESCRIPTION
This is another "next version" PR.
In addition to renaming the HOC, this PR does the following:
- Adds `babel-plugin-transform-export-default`
- Removes functionality where `waitFor` interprets the string `loading` as falsey